### PR TITLE
feat: Add 'ai 프롬프트' page with to-do list functionality

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -17,13 +17,40 @@
     {% endcomment %}
 
     {% assign pages_list = site.pages | sort:"url" %}
+    {% assign ai_prompt_node = nil %}
+    {% assign ai_prompt_rendered = false %}
+
+    {% comment %} Capture AI Prompt node first {% endcomment %}
+    {% for node_capture in pages_list %}
+      {% if node_capture.title == "AI 프롬프트" and node_capture.layout == "page" %}
+        {% assign ai_prompt_node = node_capture %}
+        {% break %}
+      {% endif %}
+    {% endfor %}
+
     {% for node in pages_list %}
-      {% if node.title != null %}
-        {% if node.layout == "page" %}
-          <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url | absolute_url }}">{{ node.title }}</a>
+      {% if node.title != null and node.layout == "page" %}
+        {% if node.title == "AI 프롬프트" %}
+          {% comment %} Don't render AI Prompt here, will be handled with/after 설정 or at the end {% endcomment %}
+          {% continue %}
+        {% endif %}
+
+        <a class="sidebar-nav-item{% if page.url == node.url %} active{% endif %}" href="{{ node.url | absolute_url }}">{{ node.title }}</a>
+
+        {% if node.title == "설정" and ai_prompt_node != nil %}
+          <a class="sidebar-nav-item{% if page.url == ai_prompt_node.url %} active{% endif %}" href="{{ ai_prompt_node.url | absolute_url }}">{{ ai_prompt_node.title }}</a>
+          {% assign ai_prompt_rendered = true %}
         {% endif %}
       {% endif %}
     {% endfor %}
+
+    {% comment %} If AI Prompt was not rendered (e.g. 설정 was not found), add it here.
+        This ensures AI Prompt is always included if it exists.
+        It will be added at the end of the list of pages.
+    {% endcomment %}
+    {% if ai_prompt_node != nil and ai_prompt_rendered == false %}
+        <a class="sidebar-nav-item{% if page.url == ai_prompt_node.url %} active{% endif %}" href="{{ ai_prompt_node.url | absolute_url }}">{{ ai_prompt_node.title }}</a>
+    {% endif %}
 
     <!-- <a class="sidebar-nav-item" href="{{ site.github.repo }}/archive/v{{ site.version }}.zip">Download</a>
     <a class="sidebar-nav-item" href="{{ site.github.repo }}">GitHub project</a>

--- a/ai_prompt.md
+++ b/ai_prompt.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: AI 프롬프트
+permalink: /ai_prompt/
+---
+
+<h1>AI 프롬프트</h1>
+
+<input type="text" id="prompt-input" />
+<button id="add-prompt-btn">추가</button>
+
+<ul id="prompt-list"></ul>
+
+<script src="/public/js/ai_prompt.js"></script>

--- a/public/js/ai_prompt.js
+++ b/public/js/ai_prompt.js
@@ -1,0 +1,48 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const promptInput = document.getElementById('prompt-input');
+  const addPromptBtn = document.getElementById('add-prompt-btn');
+  const promptList = document.getElementById('prompt-list');
+  const localStorageKey = 'aiPrompts';
+
+  let prompts = [];
+
+  // Load prompts from localStorage
+  function loadPrompts() {
+    const storedPrompts = localStorage.getItem(localStorageKey);
+    if (storedPrompts) {
+      prompts = JSON.parse(storedPrompts);
+      renderPrompts();
+    }
+  }
+
+  // Save prompts to localStorage
+  function savePrompts() {
+    localStorage.setItem(localStorageKey, JSON.stringify(prompts));
+  }
+
+  // Render prompts in the UI
+  function renderPrompts() {
+    promptList.innerHTML = ''; // Clear existing list items
+    prompts.forEach(promptText => {
+      const listItem = document.createElement('li');
+      listItem.textContent = promptText;
+      promptList.appendChild(listItem);
+    });
+  }
+
+  // Add new prompt
+  addPromptBtn.addEventListener('click', () => {
+    const promptText = promptInput.value.trim();
+
+    if (promptText !== '') {
+      prompts.push(promptText);
+      savePrompts();
+      renderPrompts(); // Re-render the list with the new item
+      promptInput.value = ''; // Clear the input field
+    }
+  });
+
+  // Initial load
+  loadPrompts();
+  console.log("ai_prompt.js loaded, DOM ready, localStorage handled.");
+});


### PR DESCRIPTION
This commit introduces a new 'ai 프롬프트' (AI Prompt) page to your website.

Key changes:
- A new page `ai_prompt.md` has been created, accessible via the permalink `/ai_prompt/`.
- The page features a simple to-do list interface allowing you to add and view text prompts.
- Prompt data is persisted in the browser's `localStorage`, so items remain across sessions on the same browser.
- A navigation link 'ai 프롬프트' has been added to the sidebar in `_includes/sidebar.html`, appearing after the '설정' (Settings) link.
- JavaScript logic for managing the to-do list (adding, displaying, saving to localStorage, loading from localStorage) is implemented in `public/js/ai_prompt.js`.