### PR TITLE
fix: Update AI Prompt page UI and add delete functionality

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="{{ '/public/css/poole.css' | absolute_url }}">
   <link rel="stylesheet" href="{{ '/public/css/syntax.css' | absolute_url }}">
   <link rel="stylesheet" href="{{ '/public/css/lanyon.css' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/public/css/custom_styles.css' | absolute_url }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ '/public/apple-touch-icon-precomposed.png' | absolute_url }}">

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,6 +3,8 @@ layout: default
 ---
 
 <div class="page">
+  {% if page.url != '/ai_prompt/' %}
   <h1 class="page-title">{{ page.title }}</h1>
+  {% endif %}
   {{ content }}
 </div>

--- a/ai_prompt.md
+++ b/ai_prompt.md
@@ -4,10 +4,8 @@ title: AI 프롬프트
 permalink: /ai_prompt/
 ---
 
-<h1>AI 프롬프트</h1>
-
 <input type="text" id="prompt-input" />
-<button id="add-prompt-btn">추가</button>
+<button id="add-prompt-btn" class="btn btn-add">추가</button>
 
 <ul id="prompt-list"></ul>
 

--- a/public/css/custom_styles.css
+++ b/public/css/custom_styles.css
@@ -1,0 +1,64 @@
+/* General Button Styling */
+.btn {
+    padding: 8px 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #f8f8f8;
+    color: #333;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background-color 0.2s ease-in-out, border-color 0.2s ease-in-out;
+    margin-left: 5px; /* For spacing if buttons are next to each other */
+}
+
+.btn:hover {
+    background-color: #eee;
+    border-color: #bbb;
+}
+
+.btn:active {
+    background-color: #ddd;
+}
+
+/* Specific styling for Add button (optional, if different look is needed) */
+.btn-add {
+    background-color: #5cb85c; /* A common 'success' or 'add' color */
+    color: white;
+    border-color: #4cae4c;
+}
+
+.btn-add:hover {
+    background-color: #4cae4c;
+    border-color: #45a045;
+}
+
+.btn-add:active {
+    background-color: #45a045;
+}
+
+/* Specific styling for Delete button */
+.btn-delete {
+    background-color: #d9534f; /* A common 'danger' or 'delete' color */
+    color: white;
+    border-color: #d43f3a;
+}
+
+.btn-delete:hover {
+    background-color: #d43f3a;
+    border-color: #c9302c;
+}
+
+.btn-delete:active {
+    background-color: #c9302c;
+}
+
+/* Ensure buttons within list items are vertically aligned if needed */
+#prompt-list li {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+
+#prompt-list li .btn-delete {
+    margin-left: auto; /* Pushes delete button to the far right */
+}

--- a/public/js/ai_prompt.js
+++ b/public/js/ai_prompt.js
@@ -11,8 +11,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const storedPrompts = localStorage.getItem(localStorageKey);
     if (storedPrompts) {
       prompts = JSON.parse(storedPrompts);
-      renderPrompts();
     }
+    renderPrompts(); // Always render, even if empty, to ensure UI consistency
   }
 
   // Save prompts to localStorage
@@ -23,11 +23,36 @@ document.addEventListener('DOMContentLoaded', () => {
   // Render prompts in the UI
   function renderPrompts() {
     promptList.innerHTML = ''; // Clear existing list items
-    prompts.forEach(promptText => {
+    prompts.forEach((promptText, index) => {
       const listItem = document.createElement('li');
       listItem.textContent = promptText;
+
+      const deleteButton = document.createElement('button');
+      deleteButton.textContent = '삭제';
+      deleteButton.className = 'btn btn-delete'; // Added classes
+      // deleteButton.style.marginLeft = '10px'; // Margin will be handled by CSS .btn or #prompt-list li .btn-delete
+      deleteButton.setAttribute('data-index', index);
+
+      deleteButton.addEventListener('click', function() {
+        // 'this' refers to the button clicked
+        const promptIndex = parseInt(this.getAttribute('data-index'), 10);
+        deletePrompt(promptIndex);
+      });
+
+      listItem.appendChild(deleteButton);
       promptList.appendChild(listItem);
     });
+  }
+
+  // Delete prompt by index
+  function deletePrompt(index) {
+    if (index >= 0 && index < prompts.length) {
+      prompts.splice(index, 1); // Remove the item from the array
+      savePrompts();          // Update localStorage
+      renderPrompts();        // Re-render the list
+    } else {
+      console.error('Invalid index for deletePrompt:', index);
+    }
   }
 
   // Add new prompt
@@ -44,5 +69,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Initial load
   loadPrompts();
-  console.log("ai_prompt.js loaded, DOM ready, localStorage handled.");
+  console.log("ai_prompt.js loaded, DOM ready, localStorage and delete functionality handled.");
 });


### PR DESCRIPTION
This commit addresses your feedback on the AI Prompt page:

- Removed duplicate/unwanted titles:
    - The explicit H1 title in `ai_prompt.md` was removed.
    - The layout `_layouts/page.html` now conditionally hides its H1 title for the `/ai_prompt/` page, ensuring no title text appears above the input controls.
- Added delete functionality:
    - Each prompt item in the list now has a "삭제" (Delete) button.
    - Clicking the delete button removes the prompt from the list and from `localStorage`.
- Styled buttons:
    - The "추가" (Add) and "삭제" (Delete) buttons have been styled for a cleaner, more modern look using new CSS classes (`.btn`, `.btn-add`, `.btn-delete`).
    - Styles are defined in `public/css/custom_styles.css`, which is now linked in `_includes/head.html`.
    - List items are also styled for better alignment of the delete button.